### PR TITLE
fix: Wording usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# vmessping
+# VMessPing
+
 ![Build Status](https://github.com/v2fly/vmessping/workflows/Go/badge.svg) 
 
 A ping prober for `vmess://` links in common seen formats.
@@ -11,69 +12,101 @@ A ping prober for `vmess://` links in common seen formats.
 
 # Download
 
-Binaries are built automaticly by Github Action.
+Binaries are built automaticly by GitHub Action.
 
-Download in [Release](https://github.com/v2fly/vmessping/releases/latest)
+Download in [Release](https://github.com/v2fly/vmessping/releases/latest) .
+
+* Arch Linux (AUR): https://aur.archlinux.org/packages/vmessping/
 
 # Usage
 
 ```
-./vmessping vmess://....
-Usage of ./vmessping:
+$ vmessping
+vmessping vmess:// ...
+Usage of vmessping:
   -c uint
-        Count. Stop after sending COUNT requests (default 9999)
+    	Count. Stop after sending COUNT requests (default 9999)
   -dest string
-        the test destination url, need 204 for success return (default "http://www.google.com/gen_204")
+    	the test destination url, need 204 for success return (default "http://www.google.com/gen_204")
   -i uint
-        inteval seconds between pings (default 1)
-  -m    use mux outbound
-  -n    show node location/outbound ip
+    	inteval seconds between pings (default 1)
+  -m	use mux outbound
+  -n	show node location/outbound ip
   -o uint
-        timeout seconds for each request (default 10)
+    	timeout seconds for each request (default 10)
   -q uint
-        fast quit on error counts
-  -v    verbose (debug log)
+    	fast quit on error counts
+  -v	verbose (debug log)
 ```
 
 # Example
+
 ```
-./vmessping "vmess://ew0KI......."
-Vmessping ver[0.0.0-src], A prober for v2ray (v2ray-core: 4.23.1)
+$ vmessping 'vmess://ew0KI ...'
+VMessPing ver[0.0.0-src], A prober for v2ray (v2ray-core: 4.23.1)
 
 Type: ws
 Addr: v2-server.address
-Port: 80
+Port: 443
 UUID: 00000000-0000-0000-0000-000000000000
+Type: 
+TLS: tls
 PS: @describe
 
-Ping http://www.google.com/gen_204: seq=1 time=770 ms
-Ping http://www.google.com/gen_204: seq=2 time=1368 ms
-Ping http://www.google.com/gen_204: seq=3 time=761 ms
-Ping http://www.google.com/gen_204: seq=4 time=761 ms
-Ping http://www.google.com/gen_204: seq=5 time=1352 ms
+Ping http://www.google.com/gen_204: seq=1 time=197 ms
+Ping http://www.google.com/gen_204: seq=2 time=81 ms
+Ping http://www.google.com/gen_204: seq=3 time=92 ms
+Ping http://www.google.com/gen_204: seq=4 time=94 ms
+Ping http://www.google.com/gen_204: seq=5 time=90 ms
 ^C
 --- vmess ping statistics ---
-5 requests made, 5 success, total time 9.106869693s
-rtt min/avg/max = 761/1002/1368 ms
+5 requests made, 5 success, total time 4.658023734s
+rtt min/avg/max = 81/110/197 ms
 ```
 
 # Compile from source
+
 ```
-git clone https://github.com/v2fly/vmessping.git
-cd vmessping/cmd/vmessping
-go build
+$ git clone https://github.com/v2fly/vmessping.git
+$ cd vmessping/cmd/vmessping
+$ go build -ldflags="-X=main.MAINVER=${pkgver} -linkmode=external"
 ```
 
 # Other tools
 
-## VmessSpeed
-
-Speedtest for vmess.
+## VMessConvert
 
 ### Usage
+
+```
+$ vmessconv
+vmessconv vmess:// ...
+Usage of usr/bin/vmessconv:
+  -n	show v2rayN / v2rayNG format
+  -q	show Quantumult format
+  -r	show Shadowrocket format
 ```
 
-./vmessspeed --help
+### Example
+
+```
+$ vmessconv 'vmess://ew0KI ...'
+VMessConvert: 0.0.0-src
+v2rayN / v2rayNG: vmess:// ...
+
+Shadowrocket: vmess:// ...
+
+Quantumult: vmess:// ...
+```
+
+## VMessSpeed
+
+Speedtest for VMess.
+
+### Usage
+
+```
+$ vmessspeed --help
 usage: vmessspeed [<flags>] <vmess>
 
 Flags:
@@ -92,15 +125,17 @@ Args:
 ### Example
 
 ```
-D:\>vmessspeed_amd64_windows.exe -s 14791 vmess://.....
+$ vmessspeed 'vmess://ew0KI ...'
 
 Type: ws
 Addr: v2-server.address
-Port: 80
+Port: 443
 UUID: 00000000-0000-0000-0000-000000000000
+Type: 
+TLS: tls
 PS: @describe
 
-Testing From IP: ...IP..ADDR....
+Testing From IP: ... IP ... ADDR ...
 
 Target Server: [14791]    63.21km Macau (Macau) by MTel
 Latency: 21.005ms

--- a/cmd/vmessconv/main.go
+++ b/cmd/vmessconv/main.go
@@ -14,14 +14,14 @@ var (
 )
 
 func main() {
-	showN := flag.Bool("n", false, "show v2rayN/NG format")
-	showRK := flag.Bool("r", false, "show shadowrocket format")
+	showN := flag.Bool("n", false, "show v2rayN / v2rayNG format")
+	showRK := flag.Bool("r", false, "show Shadowrocket format")
 	showQ := flag.Bool("q", false, "show Quantumult format")
 	flag.Parse()
 	var link string
 	if flag.NArg() == 0 {
 		if link = os.Getenv("VMESS"); link == "" {
-			fmt.Println(os.Args[0], "vmess://....")
+			fmt.Println(os.Args[0], "vmess:// ...")
 			flag.Usage()
 			os.Exit(1)
 		}
@@ -33,21 +33,21 @@ func main() {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	fmt.Println("VmessConvert:", MAINVER)
+	fmt.Println("VMessConvert:", MAINVER)
 
 	if *showN {
-		fmt.Println("V2rayN:", lk.LinkStr("ng"))
+		fmt.Println("v2rayN / v2rayNG:", lk.LinkStr("ng"))
 	}
 	if *showRK {
-		fmt.Println("ShadowRocket:", lk.LinkStr("rk"))
+		fmt.Println("Shadowrocket:", lk.LinkStr("rk"))
 	}
 	if *showQ {
 		fmt.Println("Quantumult:", lk.LinkStr("quan"))
 	}
 	if !*showN && !*showRK && !*showQ {
-		fmt.Println("V2rayN:", lk.LinkStr("ng"))
+		fmt.Println("v2rayN / v2rayNG:", lk.LinkStr("ng"))
 		fmt.Println()
-		fmt.Println("ShadowRocket:", lk.LinkStr("rk"))
+		fmt.Println("Shadowrocket:", lk.LinkStr("rk"))
 		fmt.Println()
 		fmt.Println("Quantumult:", lk.LinkStr("quan"))
 	}

--- a/cmd/vmessping/main.go
+++ b/cmd/vmessping/main.go
@@ -28,7 +28,7 @@ func main() {
 	var vmess string
 	if flag.NArg() == 0 {
 		if vmess = os.Getenv("VMESS"); vmess == "" {
-			fmt.Println(os.Args[0], "vmess://....")
+			fmt.Println(os.Args[0], "vmess:// ...")
 			flag.Usage()
 			os.Exit(1)
 		}

--- a/ping.go
+++ b/ping.go
@@ -10,7 +10,7 @@ import (
 
 func PrintVersion(mv string) {
 	fmt.Fprintf(os.Stderr,
-		"Vmessping ver[%s], A prober for v2ray (v2ray-core: %s)\n", mv, mv2ray.CoreVersion())
+		"VMessPing ver[%s], A prober for v2ray (v2ray-core: %s)\n", mv, mv2ray.CoreVersion())
 }
 
 type PingStat struct {


### PR DESCRIPTION
1. Vmess is modified to VMess.
2. ShadowRocket is modified to Shadowrocket.
3. Distinguish between v2rayN and v2rayNG.
4. Add software from Arch Linux (AUR).