### PR TITLE
feat: allow-insecure flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Download in [Release](https://github.com/v2fly/vmessping/releases/latest) .
 $ vmessping
 vmessping vmess:// ...
 Usage of vmessping:
+  -allow-insecure
+      allow insecure TLS connections
   -c uint
     	Count. Stop after sending COUNT requests (default 9999)
   -dest string
@@ -112,9 +114,11 @@ usage: vmessspeed [<flags>] <vmess>
 Flags:
       --help               Show context-sensitive help (also try --help-long and --help-man).
   -l, --list               Show available speedtest.net servers
-  -d, --debug              Show v2ray core debug log
+  -d, --debug              Show V2Ray core debug log
   -s, --server=SERVER ...  Select server id to speedtest
   -t, --timeout=TIMEOUT    Define timeout seconds. Default: 10 sec
+  -m, --mux                Use Mux outbound
+      --allow-insecure     Allow insecure TLS connections
       --version            Show application version.
 
 Args:

--- a/cmd/vmessping/main.go
+++ b/cmd/vmessping/main.go
@@ -13,14 +13,15 @@ import (
 var (
 	MAINVER = "0.0.0-src"
 
-	verbose  = flag.Bool("v", false, "verbose (debug log)")
-	showNode = flag.Bool("n", false, "show node location/outbound ip")
-	usemux   = flag.Bool("m", false, "use mux outbound")
-	desturl  = flag.String("dest", "http://www.google.com/gen_204", "the test destination url, need 204 for success return")
-	count    = flag.Uint("c", 9999, "Count. Stop after sending COUNT requests")
-	timeout  = flag.Uint("o", 10, "timeout seconds for each request")
-	inteval  = flag.Uint("i", 1, "inteval seconds between pings")
-	quit     = flag.Uint("q", 0, "fast quit on error counts")
+	verbose       = flag.Bool("v", false, "verbose (debug log)")
+	showNode      = flag.Bool("n", false, "show node location/outbound ip")
+	useMux        = flag.Bool("m", false, "use mux outbound")
+	allowInsecure = flag.Bool("allow-insecure", false, "allow insecure TLS connections")
+	desturl       = flag.String("dest", "http://www.google.com/gen_204", "the test destination url, need 204 for success return")
+	count         = flag.Uint("c", 9999, "Count. Stop after sending COUNT requests")
+	timeout       = flag.Uint("o", 10, "timeout seconds for each request")
+	inteval       = flag.Uint("i", 1, "inteval seconds between pings")
+	quit          = flag.Uint("q", 0, "fast quit on error counts")
 )
 
 func main() {
@@ -41,7 +42,7 @@ func main() {
 	signal.Notify(osSignals, os.Interrupt, os.Kill, syscall.SIGTERM)
 
 	vmessping.PrintVersion(MAINVER)
-	ps, err := vmessping.Ping(vmess, *count, *desturl, *timeout, *inteval, *quit, osSignals, *showNode, *verbose, *usemux)
+	ps, err := vmessping.Ping(vmess, *count, *desturl, *timeout, *inteval, *quit, osSignals, *showNode, *verbose, *useMux, *allowInsecure)
 	if err != nil {
 		os.Exit(1)
 	}

--- a/cmd/vmessspeed/speedtest.go
+++ b/cmd/vmessspeed/speedtest.go
@@ -26,11 +26,13 @@ var (
 	MAINVER = "0.0.0-src"
 	timeout = 180
 
-	vmessLink  = kingpin.Arg("vmess", "the vmesslink").Required().String()
-	showList   = kingpin.Flag("list", "Show available speedtest.net servers").Short('l').Bool()
-	debug      = kingpin.Flag("debug", "Show v2ray core debug log").Short('d').Bool()
-	serverIds  = kingpin.Flag("server", "Select server id to speedtest").Short('s').Ints()
-	timeoutOpt = kingpin.Flag("timeout", "Define timeout seconds. Default: 10 sec").Short('t').Int()
+	vmessLink     = kingpin.Arg("vmess", "The link of VMess").Required().String()
+	showList      = kingpin.Flag("list", "Show available speedtest.net servers").Short('l').Bool()
+	debug         = kingpin.Flag("debug", "Show V2Ray core debug log").Short('d').Bool()
+	serverIds     = kingpin.Flag("server", "Select server id to speedtest").Short('s').Ints()
+	timeoutOpt    = kingpin.Flag("timeout", "Define timeout seconds. Default: 10 sec").Short('t').Int()
+	useMux        = kingpin.Flag("mux", "Use Mux outbound").Short('m').Bool()
+	allowInsecure = kingpin.Flag("allow-insecure", "Allow insecure TLS connections").Bool()
 )
 
 func main() {
@@ -39,7 +41,7 @@ func main() {
 
 	setTimeout()
 
-	server, err := mv2ray.StartV2Ray(*vmessLink, *debug, true)
+	server, err := mv2ray.StartV2Ray(*vmessLink, *debug, *useMux, *allowInsecure)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/miniv2ray/v2ray.go
+++ b/miniv2ray/v2ray.go
@@ -23,12 +23,12 @@ import (
 	"github.com/v2fly/v2ray-core/v4/infra/conf"
 )
 
-func Vmess2Outbound(v *vmess.VmessLink, usemux bool) (*core.OutboundHandlerConfig, error) {
+func Vmess2Outbound(v *vmess.VmessLink, useMux, allowInsecure bool) (*core.OutboundHandlerConfig, error) {
 	out := &conf.OutboundDetourConfig{}
 	out.Tag = "proxy"
 	out.Protocol = "vmess"
 	out.MuxSettings = &conf.MuxConfig{}
-	if usemux {
+	if useMux {
 		out.MuxSettings.Enabled = true
 		out.MuxSettings.Concurrency = 8
 	}
@@ -80,7 +80,7 @@ func Vmess2Outbound(v *vmess.VmessLink, usemux bool) (*core.OutboundHandlerConfi
 
 	if v.TLS == "tls" {
 		s.TLSSettings = &conf.TLSConfig{
-			Insecure: true,
+			Insecure: allowInsecure,
 		}
 		if v.Host != "" {
 			s.TLSSettings.ServerName = v.Host
@@ -107,7 +107,7 @@ func Vmess2Outbound(v *vmess.VmessLink, usemux bool) (*core.OutboundHandlerConfi
 	return out.Build()
 }
 
-func StartV2Ray(vm string, verbose, usemux bool) (*core.Instance, error) {
+func StartV2Ray(vm string, verbose, useMux, allowInsecure bool) (*core.Instance, error) {
 	loglevel := commlog.Severity_Error
 	if verbose {
 		loglevel = commlog.Severity_Debug
@@ -119,7 +119,7 @@ func StartV2Ray(vm string, verbose, usemux bool) (*core.Instance, error) {
 	}
 
 	fmt.Println("\n" + lk.DetailStr())
-	ob, err := Vmess2Outbound(lk, usemux)
+	ob, err := Vmess2Outbound(lk, useMux, allowInsecure)
 	if err != nil {
 		return nil, err
 	}

--- a/ping.go
+++ b/ping.go
@@ -53,8 +53,8 @@ func (p PingStat) IsErr() bool {
 	return len(p.Delays) == 0
 }
 
-func Ping(vmess string, count uint, dest string, timeoutsec, inteval, quit uint, stopCh <-chan os.Signal, showNode, verbose, usemux bool) (*PingStat, error) {
-	server, err := mv2ray.StartV2Ray(vmess, verbose, usemux)
+func Ping(vmess string, count uint, dest string, timeoutsec, inteval, quit uint, stopCh <-chan os.Signal, showNode, verbose, useMux, allowInsecure bool) (*PingStat, error) {
+	server, err := mv2ray.StartV2Ray(vmess, verbose, useMux, allowInsecure)
 	if err != nil {
 		fmt.Println(err.Error())
 		return nil, err


### PR DESCRIPTION
I think that insecure TLS connections should not be allowed by default.