### PR TITLE
Add `VmessIntoOutboundDetour` for v2ray json config file generation

### DIFF
--- a/miniv2ray/v2ray.go
+++ b/miniv2ray/v2ray.go
@@ -26,6 +26,15 @@ import (
 
 func Vmess2Outbound(v *vmess.VmessLink, useMux, allowInsecure bool) (*core.OutboundHandlerConfig, error) {
 	out := &conf.OutboundDetourConfig{}
+	detour, err := VmessIntoOutboundDetour(v, out, useMux, allowInsecure)
+	if err != nil {
+		return nil, err
+	}
+	return detour.Build()
+}
+
+func VmessIntoOutboundDetour(v *vmess.VmessLink, template *conf.OutboundDetourConfig, useMux, allowInsecure bool) (*conf.OutboundDetourConfig, error) {
+	out := template
 	out.Tag = "proxy"
 	out.Protocol = "vmess"
 	out.MuxSettings = &conf.MuxConfig{}
@@ -105,7 +114,7 @@ func Vmess2Outbound(v *vmess.VmessLink, useMux, allowInsecure bool) (*core.Outbo
   ]
 }`, v.Add, v.Port, v.ID, v.Aid)))
 	out.Settings = &oset
-	return out.Build()
+	return out, nil
 }
 
 func StartV2Ray(vm string, verbose, useMux, allowInsecure bool) (*core.Instance, error) {

--- a/miniv2ray/v2ray.go
+++ b/miniv2ray/v2ray.go
@@ -25,15 +25,15 @@ import (
 )
 
 func Vmess2Outbound(v *vmess.VmessLink, useMux, allowInsecure bool) (*core.OutboundHandlerConfig, error) {
-	out := &conf.OutboundDetourConfig{}
-	detour, err := VmessIntoOutboundDetour(v, out, useMux, allowInsecure)
+	template := &conf.OutboundDetourConfig{}
+	detour, err := Vmess2OutboundDetour(v, useMux, allowInsecure, template)
 	if err != nil {
 		return nil, err
 	}
 	return detour.Build()
 }
 
-func VmessIntoOutboundDetour(v *vmess.VmessLink, template *conf.OutboundDetourConfig, useMux, allowInsecure bool) (*conf.OutboundDetourConfig, error) {
+func Vmess2OutboundDetour(v *vmess.VmessLink, useMux, allowInsecure bool, template *conf.OutboundDetourConfig) (*conf.OutboundDetourConfig, error) {
 	out := template
 	out.Tag = "proxy"
 	out.Protocol = "vmess"


### PR DESCRIPTION
The code in the function `Vmess2Outbound` that turn a `VmessLink` into `OutboundDetourConfig` is great!
Want reuse this code when develop some tools that use vmessping to test v2ray nodes and generate config.json: [vmessconfig](https://github.com/yindaheng98/vmessconfig) and [yindaheng98/v2confserver](https://github.com/yindaheng98/v2confserver), I made this pull request.